### PR TITLE
Implemented Expire Password

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -208,8 +208,10 @@ def login():
                     flash('Please complete your profile.', 'warning')
                     return redirect(url_for('edit_profile'))
                 
-                # If the user has not updated their password within 2 month
-                if datetime.utcnow() - user.last_password_renewal > timedelta(months = 2):
+                # If the user has not updated their password within 2 month, prompt them to edit it
+                if datetime.utcnow() - user.last_password_renewal > timedelta(weeks = 8):
+                    user.last_password_renewal = datetime.utcnow()
+                    db.session.commit()
                     flash('For security purposes, please update your password.', 'warning')
                     return redirect(url_for('edit_profile'))
 


### PR DESCRIPTION
When a user logs in after two months without changing their password, they are redirected to the edit profile page and encouraged to update their password. To avoid disrupting the user experience, even if the user does not change their password, the prompt will not occur the next time they log in for another two months.